### PR TITLE
Refactored to decrease database calls/DataFrame accesses

### DIFF
--- a/density/data/__init__.py
+++ b/density/data/__init__.py
@@ -92,14 +92,12 @@ def plot_prediction_point_estimate(conn, series, predictor):
     return p
 
 
-def df_predict(conn, series, index):
+def df_predict(series, index):
     """ Return series of predicted capacities for a provided set of times
 
     Parameters
     ----------
-    conn: psycopg2.extensions.connection
-        Connection to db
-    series: str
+    series: pd.Series
         Series of historical data for the desired floor.
     index: pd.DatetimeIndex/pd.PeriodIndex
         Index of all times for querying predictions.
@@ -115,13 +113,13 @@ def df_predict(conn, series, index):
     return predictions
 
 
-def get_historical_means(df, index):
+def get_historical_means(series, index):
     """ Return mean capacities for a floor at the same day of week and time
 
     Parameters
     ----------
-    df: pd.Dataframe
-        Dataframe consisting of Density data for the given floor.
+    series: pd.Series
+        Series consisting of Density data for the given floor.
     index: pd.DatetimeIndex/pd.PeriodIndex
         Index of dates to obtain history for
 
@@ -130,7 +128,7 @@ def get_historical_means(df, index):
     List[float]
         List of historical averages
     """
-    groups = df.groupby([df.index.dayofweek, df.index.time])
+    groups = series.groupby([series.index.dayofweek, series.index.time])
     return [groups
             .get_group((date.dayofweek, date.time()))
             .mean()

--- a/density/density.py
+++ b/density/density.py
@@ -45,6 +45,7 @@ pg_pool = psycopg2.pool.SimpleConnectionPool(
     port=app.config['PG_PORT'],
 )
 
+
 @app.before_request
 def get_connections():
     """ Get connections from the Postgres pool. """
@@ -106,6 +107,7 @@ def internal_error(e):
                    error_data=traceback.format_exc())
     # return jsonify(error="Something went wrong, the admins were notified.")
 
+
 def authorization_required(func):
     @wraps(func)
     def authorization_checker(*args, **kwargs):
@@ -166,9 +168,11 @@ def home():
     return render_template('index.html',
                            client_id=app.config['GOOGLE_CLIENT_ID'])
 
+
 @app.route('/about')
 def about():
     return render_template('about.html')
+
 
 @app.route('/predict')
 def predict():


### PR DESCRIPTION
Instead of calling to the database for every floor, only an initial call is needed. Moreover, DataFrame accesses are also decreased; instead of calling .groupby() on an entire DataFrame for every location, it is only called on the particular series for that floor.

Execution time decreased from ~6s to ~1s.

	modified:   density/data/__init__.py
	modified:   density/density.py