### PR TITLE
Update travis to use vulture during testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ before_script:
 
 script:
   - flake8
+  - vulture
   - cd density && PYTHONPATH=. py.test --verbose
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_script:
 
 script:
   - flake8
-  - vulture
+  - vulture ./
   - cd density && PYTHONPATH=. py.test --verbose
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Density
 
-[![Build Status](https://travis-ci.org/adicu/density.svg?branch=master)](https://travis-ci.org/adicu/density)
+[![Build Status](https://travis-ci.org/ADI-Labs/density.svg?branch=master)](https://travis-ci.org/adicu/density)
 
 
 Density is a project to provide easy access to the Wireless Density data from Columbia.

--- a/config/environment.yml
+++ b/config/environment.yml
@@ -11,3 +11,4 @@ dependencies:
 - pip:
   - Flask-Mail
   - oauth2client
+  - vulture     # [test]

--- a/density/db/db.py
+++ b/density/db/db.py
@@ -189,7 +189,7 @@ def get_oauth_code_for_uni(cursor, uni):
     else:
         # If the code DNE, create a new one and insert into the database.
         new_code = ''.join(random.choice(
-            string.ascii_uppercase + string.digits) for x in xrange(32))
+            string.ascii_uppercase + string.digits) for _x in xrange(32))
         query = """INSERT INTO oauth_data (uni, code)
                    VALUES (%s, %s);"""
         cursor.execute(query, [uni, new_code])

--- a/tests.sh
+++ b/tests.sh
@@ -8,6 +8,7 @@ echo '              Linting'
 echo '--------------------------------------'
 
 flake8
+vulture
 
 echo '--------------------------------------'
 echo '             Unit Tests'

--- a/tests.sh
+++ b/tests.sh
@@ -8,7 +8,7 @@ echo '              Linting'
 echo '--------------------------------------'
 
 flake8
-vulture
+vulture ./
 
 echo '--------------------------------------'
 echo '             Unit Tests'

--- a/whitelist.py
+++ b/whitelist.py
@@ -23,31 +23,6 @@ figure.yaxis.axis_line_width
 app.json_encoder
 
 # Ignore all Flask routes
-# Because vulture only performs static analysis, this file is used
-# by vulture as a whitelist module and passed as a parameter when
-# running vulture so that it'll know that certain methods are being
-# used.
-
-import density
-from bokeh import figure
-
-app = density.app
-
-# Ignore bokeh figure attribute assignment
-figure.xaxis.axis_label
-figure.xaxis.axis_line_width
-figure.xaxis.axis_line_color
-figure.xaxis.major_label_text_color
-figure.yaxis.axis_label
-figure.yaxis.axis_line_color
-figure.yaxis.major_label_text_color
-figure.yaxis.major_label_orientation
-figure.yaxis.axis_line_width
-
-# Ignore Flask app attribute assignment
-app.json_encoder
-
-# Ignore all Flask routes
 density.get_connections
 density.log_outcome
 density.page_not_found

--- a/whitelist.py
+++ b/whitelist.py
@@ -1,0 +1,39 @@
+# Because vulture only performs static analysis, this file is used
+# by vulture as a whitelist module and passed as a parameter when
+# running vulture so that it'll know that certain methods are being
+# used.
+
+from density import density
+from bokeh import figure
+
+# Ignore bokeh figure attribute assignment
+figure.xaxis.axis_label
+figure.xaxis.axis_line_width
+figure.xaxis.axis_line_color
+figure.xaxis.major_label_text_color
+figure.yaxis.axis_label
+figure.yaxis.axis_line_color
+figure.yaxis.major_label_text_color
+figure.yaxis.major_label_orientation
+figure.yaxis.axis_line_width
+
+# Ignore Flask app attribute assignment
+density.app.json_encoder
+
+# Ignore all Flask routes
+density.get_connections
+density.log_outcome
+density.page_not_found
+density.internal_error
+density.home
+density.about
+density.predict
+density.docs
+density.building_info
+density.auth
+density.redirect_uri
+density.get_day_group_data
+density.get_day_building_data
+density.get_window_group_data
+density.get_window_building_data
+density.map

--- a/whitelist.py
+++ b/whitelist.py
@@ -23,5 +23,44 @@ figure.yaxis.axis_line_width
 app.json_encoder
 
 # Ignore all Flask routes
-routes = [app.view_functions[rule.endpoint] for rule in
-          app.url_map.iter_rules()]
+# Because vulture only performs static analysis, this file is used
+# by vulture as a whitelist module and passed as a parameter when
+# running vulture so that it'll know that certain methods are being
+# used.
+
+import density
+from bokeh import figure
+
+app = density.app
+
+# Ignore bokeh figure attribute assignment
+figure.xaxis.axis_label
+figure.xaxis.axis_line_width
+figure.xaxis.axis_line_color
+figure.xaxis.major_label_text_color
+figure.yaxis.axis_label
+figure.yaxis.axis_line_color
+figure.yaxis.major_label_text_color
+figure.yaxis.major_label_orientation
+figure.yaxis.axis_line_width
+
+# Ignore Flask app attribute assignment
+app.json_encoder
+
+# Ignore all Flask routes
+density.get_connections
+density.log_outcome
+density.page_not_found
+density.internal_error
+density.home
+density.about
+density.predict
+density.docs
+density.building_info
+density.auth
+density.redirect_uri
+density.get_day_group_data
+density.get_day_building_data
+density.get_window_group_data
+density.get_window_building_data
+density.map

--- a/whitelist.py
+++ b/whitelist.py
@@ -6,6 +6,8 @@
 from density import density
 from bokeh import figure
 
+app = density.app
+
 # Ignore bokeh figure attribute assignment
 figure.xaxis.axis_label
 figure.xaxis.axis_line_width
@@ -18,22 +20,8 @@ figure.yaxis.major_label_orientation
 figure.yaxis.axis_line_width
 
 # Ignore Flask app attribute assignment
-density.app.json_encoder
+app.json_encoder
 
 # Ignore all Flask routes
-density.get_connections
-density.log_outcome
-density.page_not_found
-density.internal_error
-density.home
-density.about
-density.predict
-density.docs
-density.building_info
-density.auth
-density.redirect_uri
-density.get_day_group_data
-density.get_day_building_data
-density.get_window_group_data
-density.get_window_building_data
-density.map
+routes = [app.view_functions[rule.endpoint] for rule in
+          app.url_map.iter_rules()]


### PR DESCRIPTION
Incorporating vulture into travis so that code can be linted for dead code fragments. Updated YAML files and scripts, and added a `whitelist.py` module, which is used by vulture as a list of functions/attributes to ignore.

Turns out that because vulture only performs static analysis, by design it's going to generate a number of false positives; it marks a lot of Flask routes as unused (unless they're being explicitly used elsewhere, it seems), as well as attribute assignments for things like bokeh figures (and probably assignment of attributes to pandas DataFrames, in a similar vein). In this sense the `whitelist.py` module is somewhat longish, but helpful to have.

vulture also ignores any unused local variables that start with an underscore.