### PR TITLE
Better API key generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Density
 
-[![Build Status](https://travis-ci.org/adicu/density.svg?branch=master)](https://travis-ci.org/adicu/density)
+[![Build Status](https://travis-ci.org/ADI-Labs/density.svg?branch=master)](https://travis-ci.org/ADI-Labs/density)
 
 
 Density is a project to provide easy access to the Wireless Density data from Columbia.

--- a/config/oauth_dev_dump.sql
+++ b/config/oauth_dev_dump.sql
@@ -7,11 +7,13 @@
 DROP TABLE oauth_data CASCADE;
 CREATE TABLE oauth_data (
   uni text NOT NULL,
-  code text NOT NULL
+  code varchar(64) NOT NULL
 );
+
+CREATE UNIQUE INDEX on oauth_data (code);
 
 ALTER TABLE public.oauth_data OWNER to adi;
 
 COPY oauth_data (uni, code) FROM stdin;
-abc1234	abcdefghjijklmnopqrstuvwxyz
+abc1234	l7QGxn6doncC9Z9iPk7hykbMilRg2uV0JoIxYljtEai4o7rjVP1J9KDTudwYDNKl
 \.

--- a/config/schema.sql
+++ b/config/schema.sql
@@ -100,8 +100,10 @@ DROP TABLE oauth_data CASCADE;
 
 CREATE TABLE oauth_data (
     uni  text NOT NULL,
-    code text NOT NULL
+    code varchar(64) NOT NULL
 );
+
+CREATE UNIQUE INDEX on oauth_data (code);
 
 AlTER TABLE density_data OWNER TO adicu;
 AlTER TABLE hour_window  OWNER TO adicu;

--- a/density/db/db.py
+++ b/density/db/db.py
@@ -1,5 +1,6 @@
-import random
-import string
+import os
+import base64
+import uuid
 
 
 TABLE_NAME = 'density_data'
@@ -188,8 +189,8 @@ def get_oauth_code_for_uni(cursor, uni):
         return result['code']
     else:
         # If the code DNE, create a new one and insert into the database.
-        new_code = ''.join(random.choice(
-            string.ascii_uppercase + string.digits) for x in xrange(32))
+        token_bytes = os.urandom(32) + uuid.uuid4().bytes
+        new_code = base64.urlsafe_b64encode(token_bytes)
         query = """INSERT INTO oauth_data (uni, code)
                    VALUES (%s, %s);"""
         cursor.execute(query, [uni, new_code])

--- a/density/density.py
+++ b/density/density.py
@@ -249,6 +249,14 @@ def auth():
         uni = regex.group('uni')
         code = db.get_oauth_code_for_uni(g.cursor, uni)
         return render_template('auth.html', success=True, uni=uni, code=code)
+    except psycopg2.IntegrityError:
+        return render_template('auth.html',
+                               success=False,
+                               reason="Attempt to generate API key resulted in"
+                                      " a collision with another key in the"
+                                      " database. Please refresh to try and"
+                                      " generate a new key.")
+
     except Exception as e:
         # TODO: log errors
         print(e)

--- a/density/tests/conftest.py
+++ b/density/tests/conftest.py
@@ -9,7 +9,8 @@ def app():
 
 @pytest.fixture
 def auth_header():
-    return {'Authorization-Token': 'abcdefghjijklmnopqrstuvwxyz'}
+    token = 'l7QGxn6doncC9Z9iPk7hykbMilRg2uV0JoIxYljtEai4o7rjVP1J9KDTudwYDNKl'
+    return {'Authorization-Token': token}
 
 @pytest.yield_fixture
 def cursor():


### PR DESCRIPTION
Improved the method for generating API keys (instead of just using `os.random` and turning it into a string). Additionally, corresponding UNIQUE index + constraint for the `code` column (i.e. API key) the `oauth_data` table was added to reinforce the fact that API keys need to be unique.

Also updated build status badge in the README.